### PR TITLE
pubsub base64 error

### DIFF
--- a/lib/fluent/plugin/out_google_cloud_pubsub.rb
+++ b/lib/fluent/plugin/out_google_cloud_pubsub.rb
@@ -236,8 +236,9 @@ module Fluent
     def publish(rows)
       topic = select_topic
 
-      data = Base64.encode64(rows.to_json)
-
+      #data = Base64.encode64(rows.to_json)
+      data = Base64.strict_encode64(rows.to_json)
+      
       if data.size > @max_payload_size and rows.length > 1
           log.debug "Divide this request because a payload size exceeds the allowable limit.", topic: topic, size: data.size, length: rows.length
           mid = rows.length / 2


### PR DESCRIPTION
Base64 Error in current pubsub and td-agent 0.12.26. 
I modifing this plugin

Base64.encode64(rows.to_json)

to 

Base64.strict_encode64(rows.to_json)

then, it works.
Thanks for create pubsub plugin.